### PR TITLE
Add initial HAL/SAL 9000 framework

### DIFF
--- a/agent_test/README.md
+++ b/agent_test/README.md
@@ -1,0 +1,9 @@
+# Agent Test Framework
+
+This folder contains the initial framework for a HAL 9000/SAL 9000 style AI system.
+
+## Structure
+- `cpp/` - C++ core components.
+- `python/` - Python components and scripting interface.
+
+This is the starting point for further development.

--- a/agent_test/__init__.py
+++ b/agent_test/__init__.py
@@ -1,0 +1,1 @@
+"""Agent test package root."""

--- a/agent_test/cpp/CMakeLists.txt
+++ b/agent_test/cpp/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.10)
+project(Hal9000)
+add_executable(hal_demo main.cpp hal9000.cpp)

--- a/agent_test/cpp/hal9000.cpp
+++ b/agent_test/cpp/hal9000.cpp
@@ -1,0 +1,15 @@
+#include "hal9000.h"
+#include <iostream>
+
+Hal9000::Hal9000() {
+    // Initialization logic can be added here
+}
+
+std::string Hal9000::processInput(const std::string& input) {
+    // Placeholder processing
+    return "Processing: " + input;
+}
+
+void Hal9000::speak(const std::string& message) {
+    std::cout << "HAL9000: " << message << std::endl;
+}

--- a/agent_test/cpp/hal9000.h
+++ b/agent_test/cpp/hal9000.h
@@ -1,0 +1,14 @@
+#ifndef HAL9000_H
+#define HAL9000_H
+
+#include <string>
+
+// Basic HAL9000 interface skeleton
+class Hal9000 {
+public:
+    Hal9000();
+    std::string processInput(const std::string& input);
+    void speak(const std::string& message);
+};
+
+#endif // HAL9000_H

--- a/agent_test/cpp/main.cpp
+++ b/agent_test/cpp/main.cpp
@@ -1,0 +1,9 @@
+#include "hal9000.h"
+#include <iostream>
+
+int main() {
+    Hal9000 hal;
+    std::string response = hal.processInput("Hello, HAL");
+    hal.speak(response);
+    return 0;
+}

--- a/agent_test/python/__init__.py
+++ b/agent_test/python/__init__.py
@@ -1,0 +1,6 @@
+"""Python package for the agent test framework."""
+
+from .hal9000 import Hal9000
+from .sal9000 import Sal9000
+
+__all__ = ["Hal9000", "Sal9000"]

--- a/agent_test/python/hal9000.py
+++ b/agent_test/python/hal9000.py
@@ -1,0 +1,14 @@
+"""HAL9000 core interface."""
+
+class Hal9000:
+    def __init__(self):
+        # Initialization logic placeholder
+        pass
+
+    def process_input(self, text: str) -> str:
+        """Process incoming text and return a response."""
+        return f"Processing: {text}"
+
+    def speak(self, message: str) -> None:
+        """Output a message."""
+        print(f"HAL9000: {message}")

--- a/agent_test/python/main.py
+++ b/agent_test/python/main.py
@@ -1,0 +1,13 @@
+"""Simple entry point demonstrating HAL9000."""
+
+from .hal9000 import Hal9000
+
+
+def main() -> None:
+    hal = Hal9000()
+    response = hal.process_input("Hello, HAL")
+    hal.speak(response)
+
+
+if __name__ == "__main__":
+    main()

--- a/agent_test/python/sal9000.py
+++ b/agent_test/python/sal9000.py
@@ -1,0 +1,9 @@
+"""SAL9000 variant extending HAL9000 capabilities."""
+
+from .hal9000 import Hal9000
+
+class Sal9000(Hal9000):
+    def process_input(self, text: str) -> str:
+        # Extend or modify processing for SAL9000 specifics
+        base = super().process_input(text)
+        return base + " [SAL9000 enhancement]"


### PR DESCRIPTION
## Summary
- Scaffold agent_test with C++ and Python implementations of HAL/SAL 9000 core
- Provide C++ demo and CMake setup
- Add Python package exposing Hal9000 and Sal9000 with simple entry point

## Testing
- `g++ agent_test/cpp/main.cpp agent_test/cpp/hal9000.cpp -o agent_test/cpp/hal_demo && agent_test/cpp/hal_demo`
- `python -m py_compile agent_test/python/*.py && python -m agent_test.python.main`


------
https://chatgpt.com/codex/tasks/task_e_68a432df0d7c83339605b65f117c94a5